### PR TITLE
v0.2.0: Add CLI arg `size`; copy non-supported files now; add constants.py; add info output at startup; add a potential closing message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
-# We explicitly only allow the read permission for security reasons; no other permission is needed.
+# We explicitly allow only the read permission for security reasons; no other permission is needed.
 permissions:
   contents: read
 
 # A workflow run is made up of one or more jobs, which run in parallel by default.
-# Each job runs in a runner environment specified by runs-on.
+# Each job runs in a runner environment specified by `runs-on`.
 jobs:
 
   test:
@@ -29,11 +29,12 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      # This GitHub Action installs a Rust toolchain using rustup. It is designed for one-line concise usage and good defaults.
+      # This GitHub Action installs a Rust toolchain using "rustup".
+      # It is designed for one-line concise usage and good defaults.
       - name: Install the Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      # A GitHub Action that implements smart caching for rust/cargo projects with sensible defaults
+      # A GitHub Action that implements smart caching for rust/cargo projects with sensible defaults.
       - name: Rust Cache Action
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-      - *
   pull_request:
     types: [ opened, reopened, synchronize ]
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - *
   pull_request:
     types: [ opened, reopened, synchronize ]
     branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2024-
+## [0.2.0] - 2024-01-30
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-
+
+### Added
+
 - Optional argument for minimum file size for which a user would like to perform file size reduction.
-  - It can come in three sizes: S, M, L, for 100 kB, 500 kB and 1 MB, respectively.
+  - It comes in three sizes: S, M, L, for 100 kB, 500 kB and 1 MB, respectively.
+- Add some info messages: at startup, then for copying and for skipping files.
+- Add a closing message that warns users in case of an error.
+- GitHub action "ci.yml" ("release.yml" had already been there).
+
+### Changed
+
+- When source and destination folders are different, non-supported files will simply be copied to the destination.
+  - Previously, they would be left out.
+- Updated `README.md` with Examples and some new notes.
 
 ## [0.1.0] - 2023-12-29
 This is the very first (initial) fully-functioning version of the library and the program.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If satisfied with the result, original images can be deleted afterwards easily t
 - A minimum file size for which a user would like to perform file size reduction: `-s {s,m,l,S,M,L}`, `--size {s,m,l,S,M,L}`
     - S = 100 kB, M = 500 kB, L = 1 MB
     - Files that are smaller than the designated size will simply be copied to the destination folder.
-    - If this option is left out, then all files are considered for size reduction; i.e., minimal size is 0.
+    - If this option is left out, then all files are considered for size reduction; i.e., minimal considered size is 0.
 
 ### Examples
 See below for how to prepare the application for running.  

--- a/README.md
+++ b/README.md
@@ -7,18 +7,20 @@
 ## Description
 Reduces size of images in a folder (and optionally sub-folders, recursively).
 
-Supports JPEG and PNG formats.
+Supports JPEG and PNG image formats, with the following file extensions (case-insensitive): `jpg`, `jpeg`, `png`.
 
 This is useful for archiving of photos, for example, as they look the same on a display even with a reduced file size.  
-This application reduces the file sizes of the images in bulk.
+This application reduces file sizes of images in bulk.
 
 By default, keeps the original images and creates copies with reduced file size.
 
 By default, copies the entire folder tree, with all sub-folders that exist in the source tree.  
 The target folder tree will be created automatically, and the new reduced-size images will be copied properly to their respective paths.  
-It is only required to provide the root target folder, and it will also be created if it doesn't exist.
+It is only required to provide the root target folder, and it will also be created if it doesn't exist.  
+Non-supported files will simply be copied to the destination.
 
-The destination folder can be the same as the source folder, in which case the original images will be **overwritten**, and not retained.
+The destination folder can be the same as the source folder, in which case the original images will be **overwritten**, and not retained.  
+Other, non-supported files, will be retained.
 
 If there is enough disk space, it is advised to specify a different destination folder than the source folder,
 so that the original images can be retained and the newly-created reduced-size images can be inspected for quality.  
@@ -29,11 +31,25 @@ If satisfied with the result, original images can be deleted afterwards easily t
 ## Options
 - Look into subdirectories recursively (process the entire tree); recommended: `-r`, `--recursive`
 - Reduce both image dimensions by half: `--resize`
-- JPEG quality, on a scale from 1 (worst) to 100 (best); the default is 75; ignored in case of PNGs: `--quality <QUALITY>`
+- JPEG quality, on a scale from 1 (worst) to 100 (best); the default is 75; ignored in case of PNGs: `-q`, `--quality <QUALITY>`
+- A minimum file size for which a user would like to perform file size reduction: `-s {s,m,l,S,M,L}`, `--size {s,m,l,S,M,L}`
+    - S = 100 kB, M = 500 kB, L = 1 MB
+    - Files that are smaller than the designated size will simply be copied to the destination folder.
+    - If this option is left out, then all files are considered for size reduction; i.e., minimal size is 0.
+
+### Examples
+See below for how to prepare the application for running.  
+The file paths in the examples are for Windows.
+- `reduce_image_size D:\img_src D:\img_dst`
+- `reduce_image_size D:\img_src D:\img_dst -r`
+- `reduce_image_size D:\img_src D:\img_dst -r -s m`
+- `reduce_image_size D:\img_src D:\img_dst --recursive --size L`
+- `reduce_image_size D:\img_src D:\img_dst -r --resize -q 60 -s l`
+- `reduce_image_size D:\img_src D:\img_dst --recursive --resize --quality 60 --size L`
 
 ## Notes
 - Developed in Rust 1.74.1.
-- Tested on x86-64 CPUs with Windows 10 and Windows 11.
+- Tested on x86-64 CPUs on Windows 10 and Windows 11.
 - Also tested on WSL - Ubuntu 22.04.2 LTS (GNU/Linux 5.15.133.1-microsoft-standard-WSL2 x86_64) on Windows 11.
 - Other OSes haven't been tested, but should work.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,8 @@
 
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::builder::PossibleValue;
+use clap::{Parser, ValueEnum};
 
 use crate::constants::QUALITY;
 
@@ -31,4 +32,71 @@ pub struct Args {
     #[arg(short, long, default_value_t = QUALITY,
     value_parser = clap::value_parser!(i32).range(1..=100))]
     pub quality: i32,
+
+    /// A minimum file size for which to perform file size reduction;
+    /// DEFAULT = 0, S = 100 kB, M = 500 kB, L = 1 MB
+    #[arg(short, long, default_value_t = SizeCLI::DEFAULT)]
+    pub size: SizeCLI,
+}
+
+/// A minimum file size for which to perform file size reduction;
+/// DEFAULT = 0, S = 100 kB, M = 500 kB, L = 1 MB
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum SizeCLI {
+    DEFAULT,
+    S,
+    M,
+    L,
+}
+
+impl SizeCLI {
+    /// Report all `possible_values`.
+    pub fn possible_values() -> impl Iterator<Item = PossibleValue> {
+        Self::value_variants()
+            .iter()
+            .filter_map(ValueEnum::to_possible_value)
+    }
+}
+
+impl Default for SizeCLI {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+impl std::fmt::Display for SizeCLI {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.to_possible_value()
+            .expect("No values are skipped.")
+            .get_name()
+            .fmt(f)
+    }
+}
+
+impl std::str::FromStr for SizeCLI {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        for variant in Self::value_variants() {
+            if variant.to_possible_value().unwrap().matches(s, false) {
+                return Ok(*variant);
+            }
+        }
+        Err(format!("Invalid variant: {s}"))
+    }
+}
+
+impl ValueEnum for SizeCLI {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::DEFAULT, Self::S, Self::M, Self::L]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(match self {
+            Self::DEFAULT => PossibleValue::new("DEFAULT"),
+            Self::S => PossibleValue::new("S").alias("s"),
+            Self::M => PossibleValue::new("M").alias("m"),
+            Self::L => PossibleValue::new("L").alias("l"),
+        })
+    }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,3 +2,16 @@
 
 /// JPEG quality default value
 pub const QUALITY: i32 = 75;
+
+/// A minimum file size for which to perform file size reduction.
+/// - DEFAULT = 0
+/// - S = 100 kB
+/// - M = 500 kB
+/// - L = 1 MB
+#[derive(Debug)]
+pub enum Size {
+    DEFAULT = 0,
+    S = 102400,
+    M = 512000,
+    L = 1048576,
+}

--- a/src/logic.rs
+++ b/src/logic.rs
@@ -295,7 +295,7 @@ pub fn process_images(
         let file_size = src_path.metadata().expect("Expected file metadata.").len();
         let extension = src_path.extension();
 
-        // Copy or skip a file if it is not big enough, or has no extension, or if its extension is not supported.
+        // Copy or skip a file if it is not large enough, or has no extension, or if its extension is not supported.
         if file_size >= size && extension.is_some() {
             match extension.unwrap().to_string_lossy().to_lowercase().as_str() {
                 "jpg" | "jpeg" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
         SizeCLI::S => Size::S,
         SizeCLI::M => Size::M,
         SizeCLI::L => Size::L,
-    } as i32;
+    } as u64;
 
     if Path::new(&dst_dir).is_file() {
         println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
     println!("\nTook {:.3?} to complete.", start.elapsed());
 
     if has_error {
-        println!("\nThere were some ERRORS and some files were skipped.");
+        println!("\nThere were some ERRORS and some files were SKIPPED.");
         println!("It was not possible to reduce their size OR to copy them.");
         println!("Please review the [ERROR] messages so you don't potentially lose those files.\n");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,18 +4,20 @@
 //!
 //! The binary (executable) crate.
 
+use std::io::{stdout, Write};
 use std::path::Path;
 use std::time::Instant;
 
 use clap::Parser;
 
-use reduce_image_size::cli::Args;
+use reduce_image_size::cli::{Args, SizeCLI};
+use reduce_image_size::constants::Size;
 use reduce_image_size::logic::process_images;
 
 /// The program's entry point.
 ///
-/// Parses CLI arguments, calls the image processing function,
-/// and in the end prints the total execution time.
+/// Parses CLI arguments, prints program configuration, calls the image processing function,
+/// and in the end prints the total execution time and potential warning about errors.
 fn main() {
     let start = Instant::now();
 
@@ -26,6 +28,13 @@ fn main() {
     let resize = args.resize;
     let quality = args.quality;
 
+    let size = match args.size {
+        SizeCLI::DEFAULT => Size::DEFAULT,
+        SizeCLI::S => Size::S,
+        SizeCLI::M => Size::M,
+        SizeCLI::L => Size::L,
+    } as i32;
+
     if Path::new(&dst_dir).is_file() {
         println!(
             "\"{}\" exists and is a file! Provide a proper target directory.",
@@ -34,7 +43,19 @@ fn main() {
         return;
     }
 
-    process_images(src_dir, dst_dir, recursive, resize, quality);
+    println!("Process recursively: {recursive}");
+    println!("Reduce image dimensions: {resize}");
+    println!("Minimum image file size for processing is {size:?} bytes.");
+    println!("JPEG quality = {quality}\n");
+    stdout().flush().expect("Failed to flush stdout.");
+
+    let has_error = process_images(src_dir, dst_dir, recursive, resize, quality, size);
 
     println!("\nTook {:.3?} to complete.", start.elapsed());
+
+    if has_error {
+        println!("\nThere were some ERRORS and some files were skipped.");
+        println!("It was not possible to reduce their size OR to copy them.");
+        println!("Please review the [ERROR] messages so you don't potentially lose those files.\n");
+    }
 }


### PR DESCRIPTION
v0.2.0: Add CLI arg `size`; copy non-supported files now; add constants.py; add info output at startup; add a potential closing message

## [0.2.0] - 2024-01-30

### Added

- Optional argument for minimum file size for which a user would like to perform file size reduction.
  - It comes in three sizes: S, M, L, for 100 kB, 500 kB and 1 MB, respectively.
- Add some info messages: at startup, then for copying and for skipping files.
- Add a closing message that warns users in case of an error.
- GitHub action "ci.yml" ("release.yml" had already been there).

### Changed

- When source and destination folders are different, non-supported files will simply be copied to the destination.
  - Previously, they would be left out.
- Updated `README.md` with Examples and some new notes.
